### PR TITLE
Added address parameter to resource_ip_address

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Note: The gateway_offset value can be positive (offset start at the first addres
 ### IP Address
 IP Address resource allows to assign an IP from the following arguments:
 
+* `address` - (Optional) Specify the IP address to use. If omitted, one will be assigned by SOLIDServer.
 * `space` - (Required) The name of the space into which creating the IP address.
 * `subnet` - (Required) The name of the subnet into which creating the IP address.
 * `name` - (Required) The name of the IP address to create. If a FQDN is specified and SOLIDServer is configured to sync IPAM to DNS, this will create the appropriate DNS A Record.

--- a/solidserver/resource_ip_address.go
+++ b/solidserver/resource_ip_address.go
@@ -38,8 +38,9 @@ func resourceipaddress() *schema.Resource {
       "address": &schema.Schema{
         Type:     schema.TypeString,
         Description: "The provisionned IP address.",
-        Required: false,
-        Computed: true,
+        Optional: true,
+        ForceNew: true,
+        Default: "",
       },
       /*
       ** "device_id": &schema.Schema{
@@ -122,7 +123,14 @@ func resourceipaddressCreate(d *schema.ResourceData, meta interface{}) error {
 
   var site_id         string = ipsiteidbyname(d.Get("space").(string), meta)
   var subnet_id       string = ipsubnetidbyname(site_id, d.Get("subnet").(string), true, meta)
-  var ip_addresses  []string = ipaddressfindfree(subnet_id, meta)
+  var ip_addresses  []string
+
+  // Determine if the IP was passed in or we should generate it
+  if len(d.Get("address").(string)) > 0 {
+    ip_addresses = []string{d.Get("address").(string)}
+  } else {
+    ip_addresses = ipaddressfindfree(subnet_id, meta)
+  }
 
   for i := 0; i < len(ip_addresses); i++ {
     // Building parameters


### PR DESCRIPTION
Added optional `address parameter` to `resource_ip_address` to allow it to
be set instead of generated. We have some use cases where an external entity is authoritative for IP allocation instead of SOLIDServer.