### PR TITLE
Added additional_trust_certs_file parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ SOLIDServer provider supports the following arguments:
 * `password` - (Required) Password associated with the username. Can be stored in `SOLIDServer_PASSWORD` environment variable.
 * `host` - (Required) IP Address of the SOLIDServer REST API endpoint. Can be stored in `SOLIDServer_HOST` environment variable.
 * `sslverify` - (Optional) Enable/Disable ssl certificate check. Can be stored in `SOLIDServer_SSLVERIFY` environment variable.
+* `additional_trust_certs_file` - (Optional) Path to a file containing concatenated PEM-formatted certificates that will be trusted in addition to system defaults.
 
 ```
 provider "solidserver" {

--- a/solidserver/provider.go
+++ b/solidserver/provider.go
@@ -33,6 +33,13 @@ func Provider() terraform.ResourceProvider {
         DefaultFunc: schema.EnvDefaultFunc("SOLIDServer_SSLVERIFY", true),
         Description: "Enable/Disable ssl verify (Default : enabled)",
       },
+      "additional_trust_certs_file": &schema.Schema{
+        Type:        schema.TypeString,
+        Required:    false,
+        Optional:    true,
+        DefaultFunc: schema.EnvDefaultFunc("SOLIDServer_ADDITIONALTRUSTCERTSFILE", nil),
+        Description: "PEM formatted file with additional certificates to trust for TLS connection",
+      },
     },
 
     ResourcesMap: map[string]*schema.Resource{
@@ -54,6 +61,7 @@ func ProviderConfigure(d *schema.ResourceData) (interface{}, error) {
     d.Get("username").(string),
     d.Get("password").(string),
     d.Get("sslverify").(bool),
+    d.Get("additional_trust_certs_file").(string),
   )
 
   return s, nil

--- a/solidserver/soliderver.go
+++ b/solidserver/soliderver.go
@@ -4,57 +4,80 @@ import (
   "github.com/alexissavin/gorequest"
   "encoding/base64"
   "crypto/tls"
+  "crypto/x509"
   "net/http"
   "net/url"
   "fmt"
-  //"log"
+  "log"
+  "io/ioutil"
 )
 
 type SOLIDserver struct {
-  Host        string
-  Username    string
-  Password    string
-  BaseUrl     string
-  SSLVerify   bool
+  Host                     string
+  Username                 string
+  Password                 string
+  BaseUrl                  string
+  SSLVerify                bool
+  AdditionalTrustCertsFile string
 }
 
-func NewSOLIDserver(host string, username string, password string, sslverify bool) (*SOLIDserver) {
+func NewSOLIDserver(host string, username string, password string, sslverify bool, certsfile string) *SOLIDserver {
   s := &SOLIDserver{
-    Host:      host,
-    Username:  username,
-    Password:  password,
-    BaseUrl:   "https://" + host,
-    SSLVerify: sslverify,
+    Host:                     host,
+    Username:                 username,
+    Password:                 password,
+    BaseUrl:                  "https://" + host,
+    SSLVerify:                sslverify,
+    AdditionalTrustCertsFile: certsfile,
   }
 
   return s
 }
 
 func (s *SOLIDserver) Request(method string, service string, parameters *url.Values) (*http.Response, string, []error) {
+  // Get the SystemCertPool, continue with an empty pool on error
+  log.Printf("[DEBUG] AdditionalTrustCertsFile = %s", s.AdditionalTrustCertsFile)
+  rootCAs, err := x509.SystemCertPool()
+  if rootCAs == nil || err != nil {
+    rootCAs = x509.NewCertPool()
+  }
+  if s.AdditionalTrustCertsFile != "" {
+    certs, err := ioutil.ReadFile(s.AdditionalTrustCertsFile)
+    log.Printf("[DEBUG] Certificates = %s", certs)
+    if err != nil {
+      log.Fatalf("Failed to append %q to RootCAs: %v", s.AdditionalTrustCertsFile, err)
+    }
+
+    log.Printf("[DEBUG] Cert Subjects Before Append = %d", len(rootCAs.Subjects()))
+    if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
+      log.Println("No certs appended, using system certs only")
+    }
+    log.Printf("[DEBUG] Cert Subjects After Append = %d", len(rootCAs.Subjects()))
+  }
   apiclient := gorequest.New()
 
   switch method {
   case "post":
     return apiclient.Post(fmt.Sprintf("%s/%s?%s", s.BaseUrl, service, parameters.Encode())).
-    TLSClientConfig(&tls.Config{InsecureSkipVerify: !s.SSLVerify}).
+    TLSClientConfig(&tls.Config{InsecureSkipVerify: !s.SSLVerify, RootCAs: rootCAs}).
     Set("X-IPM-Username", base64.StdEncoding.EncodeToString([]byte(s.Username))).
     Set("X-IPM-Password", base64.StdEncoding.EncodeToString([]byte(s.Password))).
     End()
   case "put":
     return apiclient.Put(fmt.Sprintf("%s/%s?%s", s.BaseUrl, service, parameters.Encode())).
-    TLSClientConfig(&tls.Config{InsecureSkipVerify: !s.SSLVerify}).
+    TLSClientConfig(&tls.Config{InsecureSkipVerify: !s.SSLVerify, RootCAs: rootCAs}).
     Set("X-IPM-Username", base64.StdEncoding.EncodeToString([]byte(s.Username))).
     Set("X-IPM-Password", base64.StdEncoding.EncodeToString([]byte(s.Password))).
     End()
   case "delete":
     return apiclient.Delete(fmt.Sprintf("%s/%s?%s", s.BaseUrl, service, parameters.Encode())).
-    TLSClientConfig(&tls.Config{InsecureSkipVerify: !s.SSLVerify}).
+    TLSClientConfig(&tls.Config{InsecureSkipVerify: !s.SSLVerify, RootCAs: rootCAs}).
     Set("X-IPM-Username", base64.StdEncoding.EncodeToString([]byte(s.Username))).
     Set("X-IPM-Password", base64.StdEncoding.EncodeToString([]byte(s.Password))).
     End()
   case "get":
     return apiclient.Get(fmt.Sprintf("%s/%s?%s", s.BaseUrl, service, parameters.Encode())).
-    TLSClientConfig(&tls.Config{InsecureSkipVerify: !s.SSLVerify}).
+    TLSClientConfig(&tls.Config{InsecureSkipVerify: !s.SSLVerify, RootCAs: rootCAs}).
     Set("X-IPM-Username", base64.StdEncoding.EncodeToString([]byte(s.Username))).
     Set("X-IPM-Password", base64.StdEncoding.EncodeToString([]byte(s.Password))).
     End()


### PR DESCRIPTION
Added optional `additional_trust_certs_file` parameter to the provider for
referencing additional trusted certificates when accessing SOLIDServer.