### PR TITLE
Gracefully handle missing IP aliases

### DIFF
--- a/solidserver/resource_ip_alias.go
+++ b/solidserver/resource_ip_alias.go
@@ -203,6 +203,10 @@ func resourceipaliasRead(d *schema.ResourceData, meta interface{}) error {
       if errmsg, err_exist := buf[0]["errmsg"].(string); (err_exist) {
         // Log the error
         log.Printf("[DEBUG] SOLIDServer - Unable to find IP alias: %s (%s)", d.Get("name"), errmsg)
+      } else {
+        // There were no errors, but there isn't a matching alias.
+        d.SetId("")
+        return nil
       }
     } else {
       // Log the error


### PR DESCRIPTION
Gracefully handle missing IP aliases when there are multiple aliases
assigned to an IP record

We were seeing a situation where there were aliases returned from the API, but that they didn't match the alias we wanted to create.  In that case the alias didn't get correctly created.  In our testing this should fix that edge case.