### PR TITLE
Fix solidserver_ip_ptr reference in solidserver_dns_rr

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -482,7 +482,7 @@ data "solidserver_ip_ptr" "myFirstIPPTR" {
 resource "solidserver_dns_rr" "aaRecord" {
   dnsserver    = "ns.mycompany.priv"
   dnsview_name = "Internal"
-  name         = "${solidserver_ip_ptr.myFirstIPPTR.address.dname}"
+  name         = "${solidserver_ip_ptr.myFirstIPPTR.dname}"
   type         = "PTR"
   value        = "myapp.mycompany.priv"
 }


### PR DESCRIPTION
The data source solidserver_ip_ptr returns dname and not address.dname :

```
  # data.solidserver_ip_ptr.testnma2_acticall_net_PITR will be read during apply
  # (config refers to values not yet known)
 <= data "solidserver_ip_ptr" "testnma2_acticall_net_PITR"  {
      + address = (known after apply)
      + dname   = (known after apply)
      + id      = (known after apply)
    }
```