### PR TITLE
Add the ability to use lower case letters in MAC address, Closes #34

### DIFF
--- a/solidserver/resource_ip6_address.go
+++ b/solidserver/resource_ip6_address.go
@@ -3,11 +3,12 @@ package solidserver
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
 	"log"
 	"net/url"
 	"regexp"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceip6address() *schema.Resource {
@@ -69,19 +70,21 @@ func resourceip6address() *schema.Resource {
 				ForceNew:    false,
 			},
 			"mac": {
-				Type:         schema.TypeString,
-				Description:  "The MAC Address of the IP v6 address to create.",
-				ValidateFunc: validation.StringMatch(regexp.MustCompile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"), "Unsupported MAC address format."),
-				Optional:     true,
-				ForceNew:     false,
-				Default:      "",
+				Type:             schema.TypeString,
+				Description:      "The MAC Address of the IP v6 address to create.",
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"), "Unsupported MAC address format."),
+				Optional:         true,
+				ForceNew:         false,
+				DiffSuppressFunc: resourcediffsuppresscase,
+				Default:          "",
 			},
 			"class": {
 				Type:        schema.TypeString,
 				Description: "The class associated to the IP v6 address.",
 				Optional:    true,
 				ForceNew:    false,
-				Default:     "",
+
+				Default: "",
 			},
 			"class_parameters": {
 				Type:        schema.TypeMap,

--- a/solidserver/resource_ip6_address.go
+++ b/solidserver/resource_ip6_address.go
@@ -71,7 +71,7 @@ func resourceip6address() *schema.Resource {
 			"mac": {
 				Type:         schema.TypeString,
 				Description:  "The MAC Address of the IP v6 address to create.",
-				ValidateFunc: validation.StringMatch(regexp.MustCompile("^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$"), "Unsupported MAC address format."),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"), "Unsupported MAC address format."),
 				Optional:     true,
 				ForceNew:     false,
 				Default:      "",

--- a/solidserver/resource_ip6_mac.go
+++ b/solidserver/resource_ip6_mac.go
@@ -35,7 +35,7 @@ func resourceip6mac() *schema.Resource {
 			"mac": {
 				Type:             schema.TypeString,
 				Description:      "The MAC Address o map with the IP v6 address.",
-				ValidateFunc:     validation.StringMatch(regexp.MustCompile("^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$"), "Unsupported MAC address format."),
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"), "Unsupported MAC address format."),
 				DiffSuppressFunc: resourcediffsuppresscase,
 				Required:         true,
 				ForceNew:         true,

--- a/solidserver/resource_ip_address.go
+++ b/solidserver/resource_ip_address.go
@@ -3,11 +3,12 @@ package solidserver
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
 	"log"
 	"net/url"
 	"regexp"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceipaddress() *schema.Resource {
@@ -69,12 +70,13 @@ func resourceipaddress() *schema.Resource {
 				ForceNew:    false,
 			},
 			"mac": {
-				Type:         schema.TypeString,
-				Description:  "The MAC Address of the IP address to create.",
-				ValidateFunc: validation.StringMatch(regexp.MustCompile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"), "Unsupported MAC address format."),
-				Optional:     true,
-				ForceNew:     false,
-				Default:      "",
+				Type:             schema.TypeString,
+				Description:      "The MAC Address of the IP address to create.",
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"), "Unsupported MAC address format."),
+				Optional:         true,
+				ForceNew:         false,
+				DiffSuppressFunc: resourcediffsuppresscase,
+				Default:          "",
 			},
 			"class": {
 				Type:        schema.TypeString,

--- a/solidserver/resource_ip_address.go
+++ b/solidserver/resource_ip_address.go
@@ -71,7 +71,7 @@ func resourceipaddress() *schema.Resource {
 			"mac": {
 				Type:         schema.TypeString,
 				Description:  "The MAC Address of the IP address to create.",
-				ValidateFunc: validation.StringMatch(regexp.MustCompile("^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$"), "Unsupported MAC address format."),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"), "Unsupported MAC address format."),
 				Optional:     true,
 				ForceNew:     false,
 				Default:      "",

--- a/solidserver/resource_ip_mac.go
+++ b/solidserver/resource_ip_mac.go
@@ -35,7 +35,7 @@ func resourceipmac() *schema.Resource {
 			"mac": {
 				Type:             schema.TypeString,
 				Description:      "The MAC Address o map with the IP address.",
-				ValidateFunc:     validation.StringMatch(regexp.MustCompile("^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$"), "Unsupported MAC address format."),
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"), "Unsupported MAC address format."),
 				DiffSuppressFunc: resourcediffsuppresscase,
 				Required:         true,
 				ForceNew:         true,


### PR DESCRIPTION
Fixes the regex to allow for lower case letters in a MAC address