### PR TITLE
Feature/import extra parameters ip subnet

### DIFF
--- a/solidserver/resource_ip_subnet.go
+++ b/solidserver/resource_ip_subnet.go
@@ -551,7 +551,6 @@ func resourceipsubnetImportState(d *schema.ResourceData, meta interface{}) ([]*s
 			}
 
 			for ck := range currentClassParameters {
-				//need to pull in parameters set in config, not in state (which is I htink what this is doing)
 				if rv, rvExist := retrievedClassParameters[ck]; rvExist {
 					computedClassParameters[ck] = rv[0]
 				} else {


### PR DESCRIPTION
Add extra import parameters to prevent recreation of resource.   

When importing some ip_subnets the provider wanted to delete/create on my next apply due to some missing parameters in the import that had ForceNew set.  Added them in to avoid this.